### PR TITLE
parallel saving for agencies

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -64,68 +64,72 @@ var agenciesInfo = config.agencies.map(agencyConfig => {
     return agencyConfig;
 });
 
-async function saveVehicles() {
-    const promises = agenciesInfo.map(async agencyInfo => {
-        const unixTime = Date.now();
-        const providerCode = providers[agencyInfo.provider];
-        let savingFailed = false;
-        try {
-            const db = await UpdatingGtfsFeed.getFeed(agencyInfo.id, Date.now());
-            
-            if (!providerCode) throw new Error("Invalid provider name");
+async function saveVehicles(agencyInfo: Agency) {
+    const unixTime = Date.now();
 
-            if (agencyInfo.tripUpdatesUrl !== undefined) {
-                await providerCode.getTripUpdates(agencyInfo).then(updates => {
-                    return writeTripUpdatesToSink(db, agencyInfo, unixTime, updates);
-                });
-            }
-            await providerCode.getVehicles(agencyInfo).then(vehicles => {
-                return writeToSink(db, agencyInfo, unixTime, vehicles).then(() => {
-                    return writeToS3(s3Bucket, agencyInfo.id, unixTime, vehicles).catch(e => {
-                        console.log("Error saving to S3: ", e)
-                        throw e;
-                    })
-                });
+    const providerCode = providers[agencyInfo.provider];
+    let savingFailed = false;
+    try {
+        const db = await UpdatingGtfsFeed.getFeed(agencyInfo.id, Date.now());
+        
+        if (!providerCode) throw new Error("Invalid provider name");
+
+        if (agencyInfo.tripUpdatesUrl !== undefined) {
+            await providerCode.getTripUpdates(agencyInfo).then(updates => {
+                return writeTripUpdatesToSink(db, agencyInfo, unixTime, updates);
             });
+        }
+        await providerCode.getVehicles(agencyInfo).then(vehicles => {
+            return writeToSink(db, agencyInfo, unixTime, vehicles).then(() => {
+                return writeToS3(s3Bucket, agencyInfo.id, unixTime, vehicles).catch(e => {
+                    console.log("Error saving to S3: ", e)
+                    throw e;
+                })
+            });
+        });
 
-            logEventWithAgency("agency-gtfs-saved", agencyInfo.id);
-        } catch (e) {
-            // todo: report these errors to an error tracking service
+        logEventWithAgency("agency-gtfs-saved", agencyInfo.id);
+    } catch (e) {
+        // todo: report these errors to an error tracking service
             // Use console.log instead of console.error as to avoid downtime from Kubernetes restarts (10-sec or more)
             logEventWithAgency("agency-gtfs-save-failed", agencyInfo.id);
             console.warn("WARN: saving vehicles / trip updates failed for " + agencyInfo.id + " " + e);
             savingFailed = true;
             // throw e; 
-        }
-        if (savingFailed) {
-            try {
-                if (!providerCode) throw new Error("Invalid provider name");
-                await providerCode.getVehicles(agencyInfo).then(vehicles => {
-                    return writeToS3(s3Bucket, agencyInfo.id, unixTime, vehicles).catch(e => {
-                        console.log("Error saving to S3: ", e)
-                    });
+    }
+    if (savingFailed) {
+        try {
+            if (!providerCode) throw new Error("Invalid provider name");
+            await providerCode.getVehicles(agencyInfo).then(vehicles => {
+                return writeToS3(s3Bucket, agencyInfo.id, unixTime, vehicles).catch(e => {
+                    console.log("Error saving to S3: ", e)
                 });
-            } catch (e) {
-                console.log("Error saving vehicles to S3 for " + agencyInfo.id + " " + e);
-                logEventWithAgency("agency-gtfs-save-s3-failed", agencyInfo.id);
-            }
+            });
+        } catch (e) {
+            console.log("Error saving vehicles to S3 for " + agencyInfo.id + " " + e);
+            logEventWithAgency("agency-gtfs-save-s3-failed", agencyInfo.id);
         }
-    });
-
-    await Promise.all(promises);
-    return;
+    }
 }
 
-function saveVehiclesRepeat() {
-    saveVehicles().then(() => {
-        setTimeout(saveVehiclesRepeat, interval);
-    });
+function saveVehicleRepeatForAgency(agencyInfo: Agency) {
+    const startTime = Date.now();
+    saveVehicles(agencyInfo)
+        .catch(e => console.error(`Error in saveVehicles for agency ${agencyInfo.id}:`, e))
+        .finally(() => {
+            const endTime = Date.now();
+            const duration = endTime - startTime;
+            const waitTime = Math.max(interval - duration, 500);
+            setTimeout(() => saveVehicleRepeatForAgency(agencyInfo), waitTime);
+        });
 }
 
 async function start() {
-    // Uncomment to load the GTFS (it's currently loaded and already exists in gtfs.db
     await migrateDbs();
-    saveVehiclesRepeat();
+    // Start independent loops for each agency
+    agenciesInfo.forEach(agencyInfo => {
+        saveVehicleRepeatForAgency(agencyInfo);
+    });
 }
 
 start().catch(e => {

--- a/src/providers/gtfs-realtime.ts
+++ b/src/providers/gtfs-realtime.ts
@@ -14,7 +14,10 @@ async function getTripUpdates(config: Agency): Promise<GtfsRealtimeBindings.tran
 
     console.log("fetching trip updates from " + url);
 
-    const response = await axios.get(url, {responseType: "arraybuffer"});
+    const response = await axios.get(url, {
+        responseType: "arraybuffer",
+        timeout: 30000, // 30 seconds total timeout
+    });
 
     const feed = decodeFeedMessage(response.data);
 
@@ -50,7 +53,6 @@ async function getVehicles(config: Agency) {
     };
 
     const gtfsFeed = await UpdatingGtfsFeed.getFeed(config.id, Date.now());
-
 
     return new Promise((resolve, reject) => {
         request(requestSettings, function (error, response, body) {


### PR DESCRIPTION
In the previous scheme, if some agencies have a slow endpoint then it causes the rest of the agencies to be slow as well. 

See [Google Cloud log link](https://console.cloud.google.com/logs/query;query=resource.type%3D%22k8s_container%22%0Aresource.labels.cluster_name%3D%22metrics-mvp-cluster%22%0Aresource.labels.container_name%3D%22orion-worker%22%0Aresource.labels.namespace_name%3D%22default%22%0A--%20textPayload%3D~%22WARN:%20saving%20vehicles%20%2F%20trip%20updates%20failed%20for%20metro-mn%20Error:%20connect%20ETIMEDOUT%20.*%22%0Aseverity%3E%3DERROR;cursorTimestamp=2025-03-20T09:20:25.040121025Z;startTime=2025-03-17T17:40:22.833Z;endTime=2025-03-20T17:40:22.833136Z?referrer=search&project=busviz)


The agencies saved metric also drops whenever metro-mn has an unavailable vehicle position feed: [metrics link](https://console.cloud.google.com/monitoring/alerting/policies/17495653405858143773?project=busviz)

We switch to a parallel system where agencies are independent. We also change the timing scheme so that the trip updates are fetched very X seconds, regardless of the duration of saveVehicles. 
